### PR TITLE
Vstプラグイン読み込み

### DIFF
--- a/module/midi_edit.py
+++ b/module/midi_edit.py
@@ -1,0 +1,1 @@
+import mido

--- a/module/vst.py
+++ b/module/vst.py
@@ -1,1 +1,22 @@
 import dawdreamer
+
+import PySide6
+from PySide6.QtWidgets import (QApplication, QWidget)
+import os
+import sys
+
+class TestWindow(QWidget):              # ウィンドウ系クラスを継承すること
+    def __init__(self, parent=None):    # parentは他にウィンドウを表示させる場合に指定する
+        super().__init__(parent)        # 継承元クラス（ここではQWidget）を初期化
+
+
+if __name__ == "__main__":
+    # 環境変数にPySide6を登録
+    dirname = os.path.dirname(PySide6.__file__)
+    plugin_path = os.path.join(dirname, 'plugins', 'platforms')
+    os.environ['QT_QPA_PLATFORM_PLUGIN_PATH'] = plugin_path
+    
+    app = QApplication(sys.argv)    # PySide6の実行
+    window = TestWindow()           # ユーザがコーディングしたクラス
+    window.show()                   # PySide6のウィンドウを表示
+    sys.exit(app.exec())            # PySide6の終了

--- a/module/vst.py
+++ b/module/vst.py
@@ -2,21 +2,16 @@ import dawdreamer
 
 import PySide6
 from PySide6.QtWidgets import (QApplication, QWidget)
-import os
-import sys
 
 class TestWindow(QWidget):              # ウィンドウ系クラスを継承すること
     def __init__(self, parent=None):    # parentは他にウィンドウを表示させる場合に指定する
         super().__init__(parent)        # 継承元クラス（ここではQWidget）を初期化
 
+        self.setWindowTitle('vstTest')
+
 
 if __name__ == "__main__":
-    # 環境変数にPySide6を登録
-    dirname = os.path.dirname(PySide6.__file__)
-    plugin_path = os.path.join(dirname, 'plugins', 'platforms')
-    os.environ['QT_QPA_PLATFORM_PLUGIN_PATH'] = plugin_path
-    
-    app = QApplication(sys.argv)    # PySide6の実行
-    window = TestWindow()           # ユーザがコーディングしたクラス
-    window.show()                   # PySide6のウィンドウを表示
-    sys.exit(app.exec())            # PySide6の終了
+    app = QApplication()
+    window = TestWindow()
+    window.show()
+    app.exec()

--- a/module/vst.py
+++ b/module/vst.py
@@ -1,14 +1,30 @@
 import dawdreamer
 
-import PySide6
-from PySide6.QtWidgets import (QApplication, QWidget)
-
-class TestWindow(QWidget):              # ウィンドウ系クラスを継承すること
-    def __init__(self, parent=None):    # parentは他にウィンドウを表示させる場合に指定する
-        super().__init__(parent)        # 継承元クラス（ここではQWidget）を初期化
+from PySide6.QtWidgets import (QApplication, QWidget, QPushButton)
+'''
+テスト用クラス
+'''
+class TestWindow(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
 
         self.setWindowTitle('vstTest')
+        self.resize(200, 110)
 
+        load_vst_btn = QPushButton(self)
+        load_vst_btn.move(20, 10)
+        load_vst_btn.setText('load vst')
+        # load_vst_btn.pressed.connect()
+
+        vst_option_btn = QPushButton(self)
+        vst_option_btn.move(20, 40)
+        vst_option_btn.setText('vst option')
+        # vst_option_btn.pressed.connect()
+
+        render_btn = QPushButton(self)
+        render_btn.move(20, 70)
+        render_btn.setText('render')
+        # render_btn.pressed.connect()
 
 if __name__ == "__main__":
     app = QApplication()

--- a/module/vst.py
+++ b/module/vst.py
@@ -43,7 +43,7 @@ class Vst():
     渡したmidiファイルを読み込んだプラグインで音声出力
     プラグインが読み込まれてなかったらload_vst()を先に呼ぶ
     '''
-    def render_audio(self, midi_path):
+    def render_audio(self, midi_path, duration):
         if self.isProcessorExists == True:
             self.plugin.load_midi(midi_path, clear_previous=True, beats=False, all_events=True)
 
@@ -52,13 +52,13 @@ class Vst():
             ]
 
             self.engine.load_graph(graph)
-            self.engine.render(10)
+            self.engine.render(duration)
             output = self.engine.get_audio()
 
             wavfile.write('./output.wav', self.sample_rate, output.transpose())
         else:
             self.load_vst()
-            self.render_audio(midi_path)
+            self.render_audio(midi_path, duration)
 
 '''
 テスト用ウィンドウクラス
@@ -85,7 +85,7 @@ class TestWindow(QWidget):
         self.render_btn = QPushButton(self)
         self.render_btn.move(10, 70)
         self.render_btn.setText('render')
-        self.render_btn.pressed.connect(lambda: self.vst.render_audio('/Users/k23103/Downloads/test.mid'))
+        self.render_btn.pressed.connect(lambda: self.vst.render_audio('/Users/k23103/Downloads/test.mid', 8))
 
         self.plugin_name_label = QLabel(self)
         self.plugin_name_label.move(10, 110)

--- a/module/vst.py
+++ b/module/vst.py
@@ -1,13 +1,11 @@
 from PySide6.QtWidgets import (QApplication, QWidget, QPushButton, QFileDialog, QLabel)
-
 import dawdreamer as daw
-import numpy as np
 from scipy.io import wavfile
 import os
 
-
 class Vst():
     def __init__(self, sample_rate=44100, buffer_size=128):
+        self.sample_rate = sample_rate
         self.vst_path = (str)
         self.plugin_name = 'None'
         self.engine = daw.RenderEngine(sample_rate, buffer_size)
@@ -41,7 +39,26 @@ class Vst():
         else:
             self.load_vst()
 
-    
+    '''
+    渡したmidiファイルを読み込んだプラグインで音声出力
+    プラグインが読み込まれてなかったらload_vst()を先に呼ぶ
+    '''
+    def render_audio(self, midi_path):
+        if self.isProcessorExists == True:
+            self.plugin.load_midi(midi_path, clear_previous=True, beats=False, all_events=True)
+
+            graph = [
+            (self.plugin, []),
+            ]
+
+            self.engine.load_graph(graph)
+            self.engine.render(10)
+            output = self.engine.get_audio()
+
+            wavfile.write('./output.wav', self.sample_rate, output.transpose())
+        else:
+            self.load_vst()
+            self.render_audio(midi_path)
 
 '''
 テスト用ウィンドウクラス
@@ -68,7 +85,7 @@ class TestWindow(QWidget):
         self.render_btn = QPushButton(self)
         self.render_btn.move(10, 70)
         self.render_btn.setText('render')
-        # self.render_btn.pressed.connect()
+        self.render_btn.pressed.connect(lambda: self.vst.render_audio('/Users/k23103/Downloads/test.mid'))
 
         self.plugin_name_label = QLabel(self)
         self.plugin_name_label.move(10, 110)

--- a/module/vst.py
+++ b/module/vst.py
@@ -3,6 +3,7 @@ from PySide6.QtWidgets import (QApplication, QWidget, QPushButton, QFileDialog)
 import dawdreamer as daw
 import numpy as np
 from scipy.io import wavfile
+import os
 
 
 class Vst():
@@ -10,29 +11,24 @@ class Vst():
         self.engine = daw.RenderEngine(sample_rate, buffer_size)
         self.vst_path = (str)
         self.plugin = (daw.PluginProcessor)
-        self.isProcessorExists = False # 
+        self.isProcessorExists = False
+        self.plugin_name = (str)
 
     def load_vst(self):
         file,check = QFileDialog.getOpenFileName(None, "ファイルを選択してください。","/Library/Audio/Plug-Ins","All Files (*);;vst Files (*.vst);;vst3 Files (*.vst3)")
 
         if check:
             self.vst_path = file
+            self.plugin_name = os.path.splitext(os.path.basename(self.vst_path))[0] # パスからプラグイン名取得
+            self.plugin = self.engine.make_plugin_processor(self.plugin_name, self.vst_path)
 
-        print(f'vst path: {self.vst_path}')
+            assert self.plugin.get_name() == self.plugin_name # プラグインが反映されなかった時にエラー投げる
 
-        self.plugin = self.engine.make_plugin_processor('plugin', self.vst_path)
-        assert self.plugin.get_name() == 'plugin' # プラグインが反映されなかった時にエラー投げる
-
-        self.isProcessorExists = True
-        self.vst_editer()
-
-
-
-        
+            self.isProcessorExists = True
+            self.vst_editer()
 
     def vst_editer(self):
         if self.isProcessorExists == True:
-            # print('open vst editer')
             self.plugin.open_editor()
         else:
             self.load_vst()

--- a/module/vst.py
+++ b/module/vst.py
@@ -1,12 +1,31 @@
-import dawdreamer
-
 from PySide6.QtWidgets import (QApplication, QWidget, QPushButton)
+
+import dawdreamer as daw
+import numpy as np
+from scipy.io import wavfile
+
+
+class Vst():
+    def __init__(self, sample_rate=44100, buffer_size=128):
+
+        self.vst_path = "/Library/Audio/Plug-Ins/VST3/Serum.vst3"
+        self.engine = daw.RenderEngine(sample_rate, buffer_size)
+        self.plugin = self.engine.make_plugin_processor("Serum", self.vst_path)
+
+    def vstEditer(self):
+        print('open vst editer')
+        self.plugin.open_editor()
+
+    
+
 '''
-テスト用クラス
+テスト用ウィンドウ
 '''
 class TestWindow(QWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
+
+        vst = Vst()
 
         self.setWindowTitle('vstTest')
         self.resize(200, 110)
@@ -16,10 +35,10 @@ class TestWindow(QWidget):
         load_vst_btn.setText('load vst')
         # load_vst_btn.pressed.connect()
 
-        vst_option_btn = QPushButton(self)
-        vst_option_btn.move(20, 40)
-        vst_option_btn.setText('vst option')
-        # vst_option_btn.pressed.connect()
+        vst_editer_btn = QPushButton(self)
+        vst_editer_btn.move(20, 40)
+        vst_editer_btn.setText('vst editer')
+        vst_editer_btn.pressed.connect(lambda: vst.vstEditer())
 
         render_btn = QPushButton(self)
         render_btn.move(20, 70)

--- a/module/vst.py
+++ b/module/vst.py
@@ -1,4 +1,4 @@
-from PySide6.QtWidgets import (QApplication, QWidget, QPushButton)
+from PySide6.QtWidgets import (QApplication, QWidget, QPushButton, QFileDialog)
 
 import dawdreamer as daw
 import numpy as np
@@ -8,9 +8,23 @@ from scipy.io import wavfile
 class Vst():
     def __init__(self, sample_rate=44100, buffer_size=128):
 
-        self.vst_path = "/Library/Audio/Plug-Ins/VST3/Serum.vst3"
+        self.vst_path = '/Library/Audio/Plug-Ins/VST3/Serum.vst3'
         self.engine = daw.RenderEngine(sample_rate, buffer_size)
-        self.plugin = self.engine.make_plugin_processor("Serum", self.vst_path)
+        self.plugin = self.engine.make_plugin_processor('plugin', self.vst_path)
+
+    def loadVst(self):
+        file,check = QFileDialog.getOpenFileName(None, "ファイルを選択してください。","/Library/Audio/Plug-Ins","All Files (*);;vst Files (*.vst);;vst3 Files (*.vst3)")
+
+        if check:
+            print(f'check: {check}')
+            self.vst_path = file
+
+        print(f'vst path: {self.vst_path}')
+
+        self.plugin = self.engine.make_plugin_processor('plugin', self.vst_path)
+
+
+        
 
     def vstEditer(self):
         print('open vst editer')
@@ -33,7 +47,7 @@ class TestWindow(QWidget):
         load_vst_btn = QPushButton(self)
         load_vst_btn.move(20, 10)
         load_vst_btn.setText('load vst')
-        # load_vst_btn.pressed.connect()
+        load_vst_btn.pressed.connect(lambda: vst.loadVst())
 
         vst_editer_btn = QPushButton(self)
         vst_editer_btn.move(20, 40)

--- a/module/vst.py
+++ b/module/vst.py
@@ -7,33 +7,40 @@ from scipy.io import wavfile
 
 class Vst():
     def __init__(self, sample_rate=44100, buffer_size=128):
-
-        self.vst_path = '/Library/Audio/Plug-Ins/VST3/Serum.vst3'
         self.engine = daw.RenderEngine(sample_rate, buffer_size)
-        self.plugin = self.engine.make_plugin_processor('plugin', self.vst_path)
+        self.vst_path = (str)
+        self.plugin = (daw.PluginProcessor)
+        self.isProcessorExists = False # 
 
-    def loadVst(self):
+    def load_vst(self):
         file,check = QFileDialog.getOpenFileName(None, "ファイルを選択してください。","/Library/Audio/Plug-Ins","All Files (*);;vst Files (*.vst);;vst3 Files (*.vst3)")
 
         if check:
-            print(f'check: {check}')
             self.vst_path = file
 
         print(f'vst path: {self.vst_path}')
 
         self.plugin = self.engine.make_plugin_processor('plugin', self.vst_path)
+        assert self.plugin.get_name() == 'plugin' # プラグインが反映されなかった時にエラー投げる
+
+        self.isProcessorExists = True
+        self.vst_editer()
+
 
 
         
 
-    def vstEditer(self):
-        print('open vst editer')
-        self.plugin.open_editor()
+    def vst_editer(self):
+        if self.isProcessorExists == True:
+            # print('open vst editer')
+            self.plugin.open_editor()
+        else:
+            self.load_vst()
 
     
 
 '''
-テスト用ウィンドウ
+テスト用ウィンドウクラス
 '''
 class TestWindow(QWidget):
     def __init__(self, parent=None):
@@ -47,12 +54,12 @@ class TestWindow(QWidget):
         load_vst_btn = QPushButton(self)
         load_vst_btn.move(20, 10)
         load_vst_btn.setText('load vst')
-        load_vst_btn.pressed.connect(lambda: vst.loadVst())
+        load_vst_btn.pressed.connect(lambda: vst.load_vst())
 
         vst_editer_btn = QPushButton(self)
         vst_editer_btn.move(20, 40)
         vst_editer_btn.setText('vst editer')
-        vst_editer_btn.pressed.connect(lambda: vst.vstEditer())
+        vst_editer_btn.pressed.connect(lambda: vst.vst_editer())
 
         render_btn = QPushButton(self)
         render_btn.move(20, 70)

--- a/module/vst.py
+++ b/module/vst.py
@@ -85,7 +85,7 @@ class TestWindow(QWidget):
         self.render_btn = QPushButton(self)
         self.render_btn.move(10, 70)
         self.render_btn.setText('render')
-        self.render_btn.pressed.connect(lambda: self.vst.render_audio('/Users/k23103/Downloads/test.mid', 8))
+        self.render_btn.pressed.connect(lambda: self.vst.render_audio('./test.mid', 8))
 
         self.plugin_name_label = QLabel(self)
         self.plugin_name_label.move(10, 110)

--- a/module/vst.py
+++ b/module/vst.py
@@ -1,4 +1,4 @@
-from PySide6.QtWidgets import (QApplication, QWidget, QPushButton, QFileDialog)
+from PySide6.QtWidgets import (QApplication, QWidget, QPushButton, QFileDialog, QLabel)
 
 import dawdreamer as daw
 import numpy as np
@@ -8,12 +8,16 @@ import os
 
 class Vst():
     def __init__(self, sample_rate=44100, buffer_size=128):
-        self.engine = daw.RenderEngine(sample_rate, buffer_size)
         self.vst_path = (str)
+        self.plugin_name = 'None'
+        self.engine = daw.RenderEngine(sample_rate, buffer_size)
         self.plugin = (daw.PluginProcessor)
         self.isProcessorExists = False
-        self.plugin_name = (str)
 
+    '''
+    ファインダーでvstファイルを選択
+    読み込めたらエディターを開く
+    '''
     def load_vst(self):
         file,check = QFileDialog.getOpenFileName(None, "ファイルを選択してください。","/Library/Audio/Plug-Ins","All Files (*);;vst Files (*.vst);;vst3 Files (*.vst3)")
 
@@ -27,6 +31,10 @@ class Vst():
             self.isProcessorExists = True
             self.vst_editer()
 
+    '''
+    エディターを開く
+    プラグインが読み込まれてなかったらload_vst()
+    '''
     def vst_editer(self):
         if self.isProcessorExists == True:
             self.plugin.open_editor()
@@ -42,25 +50,33 @@ class TestWindow(QWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
 
-        vst = Vst()
+        self.vst = Vst()
 
         self.setWindowTitle('vstTest')
-        self.resize(200, 110)
+        self.resize(300, 300)
 
-        load_vst_btn = QPushButton(self)
-        load_vst_btn.move(20, 10)
-        load_vst_btn.setText('load vst')
-        load_vst_btn.pressed.connect(lambda: vst.load_vst())
+        self.load_vst_btn = QPushButton(self)
+        self.load_vst_btn.move(10, 10)
+        self.load_vst_btn.setText('load vst')
+        self.load_vst_btn.pressed.connect(lambda: self.load_vst_btn_pressed())
 
-        vst_editer_btn = QPushButton(self)
-        vst_editer_btn.move(20, 40)
-        vst_editer_btn.setText('vst editer')
-        vst_editer_btn.pressed.connect(lambda: vst.vst_editer())
+        self.vst_editer_btn = QPushButton(self)
+        self.vst_editer_btn.move(10, 40)
+        self.vst_editer_btn.setText('vst editer')
+        self.vst_editer_btn.pressed.connect(lambda: self.vst.vst_editer())
 
-        render_btn = QPushButton(self)
-        render_btn.move(20, 70)
-        render_btn.setText('render')
-        # render_btn.pressed.connect()
+        self.render_btn = QPushButton(self)
+        self.render_btn.move(10, 70)
+        self.render_btn.setText('render')
+        # self.render_btn.pressed.connect()
+
+        self.plugin_name_label = QLabel(self)
+        self.plugin_name_label.move(10, 110)
+        self.plugin_name_label.setText(f'instrument: {self.vst.plugin_name}')
+
+    def load_vst_btn_pressed(self):
+        self.vst.load_vst()
+        self.plugin_name_label.setText(f'instrument: {self.vst.plugin_name}')
 
 if __name__ == "__main__":
     app = QApplication()


### PR DESCRIPTION
Vstクラスでvstの読み込み、設定、音声書き出しができるようにした

### 内容

- `Vst()`
  - `vst_path`
    - vstファイルのパス
  - `plugin_name`
    - 読み込んだプラグインの名前
  - `load_vst()`
    - vstファイルを選択して`vst_editer()`
  - `vst_editer()`
    - 読み込んだvstのエディター画面を開く
    - 読み込まれていない場合`load_vst()`
  - `render_audio(midi_path, duration)`
    - 読み込んだvstで引数のmidiファイル、長さでwav生成
    - 読み込まれていない場合先に`load_vst()`を呼んでから書き出し

### 思ってること

- 書き出すファイルをとりあえず`./output.wav`にしてるから指定できるようにするべき。midiファイルと同じ名前にしてもいいかも？
- これからプレビュー再生とかについて色々調べる(多分他のライブラリを使う？)