### PR TITLE
update: bpm関係のアップデート

### DIFF
--- a/main_layout.py
+++ b/main_layout.py
@@ -28,7 +28,7 @@ class MainWindow(QMainWindow):
         self.bpm = 120
         self.note_manager = NoteManager(self.grid_size)
         if file_path != None:
-            self.note_manager.notes = midi2note(self.midi)
+            self.note_manager.notes, self.bpm = midi2note(self.midi)
 
         # メインウィジェットとスプリッター（左右分割）
         main_widget = QWidget()
@@ -143,7 +143,7 @@ class MainWindow(QMainWindow):
         # テンポ設定用のスピンボックスを作成
         self.tempo_spinbox = QSpinBox()
         self.tempo_spinbox.setRange(10, 400)  # BPMの範囲を設定（10～400）
-        self.tempo_spinbox.setValue(120)  # デフォルトのテンポを設定
+        self.tempo_spinbox.setValue(self.bpm)  # デフォルトのテンポを設定
         self.tempo_spinbox.setSuffix(" BPM")  # スピンボックスに単位を追加
         button_layout.addWidget(self.tempo_spinbox)
 
@@ -451,14 +451,13 @@ class MainWindow(QMainWindow):
             print(f"Loaded Note ID: {note_id}, Position: x={left_x}, y={y_pos}, width={note_width}")
 
     def on_button1_click(self):
-        bpm = 120
         print("保存！")
-        self.midi = note2midi(self.note_manager.to_dict(), bpm)
+        self.midi = note2midi(self.note_manager.to_dict(), self.bpm)
         save_midi(self, self.midi, self.file_path) # midiファイルを保存
 
     def on_button2_click(self):
         save_midi(self, note2midi(self.note_manager.to_dict(), self.bpm), self.file_path)
-        self.vst.render_audio(self.file_path, note2midi(self.note_manager.to_dict(), self.bpm).legth())
+        self.vst.render_audio(self.file_path, note2midi(self.note_manager.to_dict(), self.bpm).length())
 
     def on_button3_click(self):
         self.vst.load_vst()

--- a/module/midi_edit.py
+++ b/module/midi_edit.py
@@ -46,6 +46,16 @@ def note2midi(note_manager, bpm):
 
 '''midiデータからxy座標へ変換する関数'''
 def midi2note(midi):
+    bpm = 120 # bpmのデフォルト値(もしテンポ情報が見つからなかった場合のフォールバック値)
+    for track in midi.tracks:
+        for msg in track:
+            if msg.type == 'set_tempo':
+                # テンポ情報が見つかった場合
+                tempo = msg.tempo
+                bpm = mido.tempo2bpm(tempo)
+                bpm = int(bpm) # GUI上で整数で表示されているため、int型でbpmを返す
+                print("このデータのbpmは", bpm)
+    
     # midデータを取り出して辞書型の配列に直す
     datas_mid = []
     for midMessage in midi.tracks[0]:
@@ -76,7 +86,7 @@ def midi2note(midi):
             entry = {"id": i//2 + 1, "left_x": datas_mid[i]["time"], "right_x": datas_mid[i+1]["time"], "y_pos": data_mid["note"]}
             note_manager[i//2 + 1] = {"id":entry["id"], "left_x": entry["left_x"], "right_x": entry["right_x"], "y_pos": entry["y_pos"]}
             
-    return note_manager
+    return note_manager, bpm
 
 '''y座標から音の高さに変換する関数'''
 def y2pitch(y):


### PR DESCRIPTION
- midi2noteでmidiのbpmの取得ができるようにした
- GUI上に表示されるbpmの値が固定値120からself.bpmに変更
- on_button1_clickで送っていたbpmの値がbpm = 120で直前で指定していたが、self.bpmに変更
- これにより、すべてのbpmの値をself.bpmに統一完了