### PR TITLE
fix: midiの読み込み、保存に関するバグの修正

### DIFF
--- a/main_layout.py
+++ b/main_layout.py
@@ -280,6 +280,7 @@ class MainWindow(QMainWindow):
         reply = QMessageBox.question(self, "確認", "MIDIファイルを保存しますか？",
                                      QMessageBox.Yes | QMessageBox.No | QMessageBox.Cancel, QMessageBox.Cancel)
         if reply == QMessageBox.Yes:
+            self.midi = note2midi(self.note_manager.to_dict(), self.bpm)
             self.file_path = save_midi(self, self.midi, self.file_path) # midiファイルを保存
             event.accept()  # ウィンドウを閉じる
         elif reply == QMessageBox.No:

--- a/module/midi_edit.py
+++ b/module/midi_edit.py
@@ -71,8 +71,8 @@ def midi2note(midi):
         data_mid["time"] //= SEMIQUAVER_VALUE
         data_mid["note"] -= MIDI_PITCH_ADJUST
     
-    # noteの値, on/offごとにソート
-    datas_mid.sort(key=lambda x: (x["note"], x["time"]))
+    # noteの値, timeの値, off→onごとにソート
+    datas_mid.sort(key=lambda x: (x["note"], x["time"], x["noteEnable"]))
     
     note_manager = {}
     


### PR DESCRIPTION
### fix: ×を押してから保存をすると最新状態で保存されないバグを解消
- ×を押してから保存するボタンを押した時にnote2midiを行ってmidiを更新してから保存するようにすることで最新データが保存されるように修正

### fix: 一部場合でmidi2noteで正しく読み込まれないバグを修正
- noteが隣り合わせで更に条件が合う時にmidi2noteが正しく動作しないことがあったものを途中のソート方法をnoteの値, timeの値でソートしていたものから、noteの値, timeの値, off→onでソートに変更することで修正